### PR TITLE
[actions] Refactor action register and dispatch and memory action

### DIFF
--- a/nuwa-framework/sources/actions/action_dispatcher.move
+++ b/nuwa-framework/sources/actions/action_dispatcher.move
@@ -33,13 +33,9 @@ module nuwa_framework::action_dispatcher {
     }
 
     fun init() {
-        register_actions();
     }
 
     entry fun register_actions() {
-        memory_action::register_actions();
-        response_action::register_actions();
-        transfer_action::register_actions();
     }
 
     public fun get_action_descriptions(): vector<ActionDescription> {
@@ -62,6 +58,7 @@ module nuwa_framework::action_dispatcher {
 
     /// Dispatch all actions from line-based format
     public fun dispatch_actions(_agent: &mut Object<Agent>, _response: String) {
+        abort 0
     }
 
     public fun dispatch_actions_v2(agent: &mut Object<Agent>, agent_input: AgentInputInfo, response: String) {
@@ -234,6 +231,7 @@ module nuwa_framework::action_dispatcher {
         use nuwa_framework::response_action;
         use nuwa_framework::transfer_action;
         use nuwa_framework::channel;
+        use nuwa_framework::agent_input;
 
         // Initialize
         action::init_for_test();
@@ -246,11 +244,10 @@ module nuwa_framework::action_dispatcher {
 
         let channel_id = channel::create_ai_home_channel(agent);
         // Using type-specific constructors with serialization
-        let memory_args = memory_action::create_add_memory_args(
-            test_addr,
-            string::utf8(b"User prefers detailed explanations"),
-            memory::context_preference(),
-            true
+        let memory_args = memory_action::create_remember_user_args(
+            string::utf8(b"User prefers detailed explanations"), 
+            string::utf8(b"preference"),
+            true,
         );
         
         let response_args = response_action::create_say_args(
@@ -259,7 +256,7 @@ module nuwa_framework::action_dispatcher {
         );
 
         let memory_action = create_action_call_with_object(
-            string::utf8(b"memory::add"), 
+            memory_action::action_name_remember_user(),
             memory_args
         );
         
@@ -274,8 +271,10 @@ module nuwa_framework::action_dispatcher {
         add_action(&mut mut_response, response_action);
         let test_response = response_to_str(&mut_response);
 
+        let agent_input_info = agent_input::new_agent_input_info_for_test(test_addr, string::utf8(b"{}"));
+
         // Execute actions
-        dispatch_actions(agent, test_response);
+        dispatch_actions_v2(agent, agent_input_info, test_response);
 
         // Verify memory was added
         let store = agent::borrow_memory_store(agent);

--- a/nuwa-framework/sources/actions/action_dispatcher.move
+++ b/nuwa-framework/sources/actions/action_dispatcher.move
@@ -2,12 +2,14 @@ module nuwa_framework::action_dispatcher {
     use std::string::{Self, String};
     use std::vector;
     use moveos_std::json;
+    use moveos_std::object::Object;
     use nuwa_framework::memory_action;
     use nuwa_framework::response_action;
     use nuwa_framework::transfer_action;
     use nuwa_framework::agent::Agent;
     use nuwa_framework::string_utils;
-    use moveos_std::object::Object;
+    use nuwa_framework::action::ActionDescription;
+    use nuwa_framework::agent_input::AgentInputInfo;
 
     /// Error codes
     const ERROR_INVALID_RESPONSE: u64 = 1;
@@ -40,26 +42,47 @@ module nuwa_framework::action_dispatcher {
         transfer_action::register_actions();
     }
 
+    public fun get_action_descriptions(): vector<ActionDescription> {
+        let descriptions = vector::empty();
+
+        // Register memory actions
+        let memory_descriptions = memory_action::get_action_descriptions();
+        vector::append(&mut descriptions, memory_descriptions);
+
+        // Register response actions
+        let response_descriptions = response_action::get_action_descriptions();
+        vector::append(&mut descriptions, response_descriptions);
+
+        // Register transfer actions
+        let transfer_descriptions = transfer_action::get_action_descriptions();
+        vector::append(&mut descriptions, transfer_descriptions);
+
+        descriptions
+    }
+
     /// Dispatch all actions from line-based format
-    public fun dispatch_actions(agent: &mut Object<Agent>, response: String) {
+    public fun dispatch_actions(_agent: &mut Object<Agent>, _response: String) {
+    }
+
+    public fun dispatch_actions_v2(agent: &mut Object<Agent>, agent_input: AgentInputInfo, response: String) {
         let action_response = parse_line_based_response(&response);
         let actions = action_response.actions;
         let i = 0;
         let len = vector::length(&actions);
         while (i < len) {
             let action_call = vector::borrow(&actions, i);
-            execute_action(agent, action_call);
+            execute_action(agent, &agent_input, action_call);
             i = i + 1;
         };
     }
 
     /// Execute a single action call
-    fun execute_action(agent: &mut Object<Agent>, action_call: &ActionCall) {
+    fun execute_action(agent: &mut Object<Agent>, agent_input: &AgentInputInfo, action_call: &ActionCall) {
         let action_name = &action_call.action;
         let args = &action_call.args;
 
         if (string_utils::starts_with(action_name, &b"memory::")) {
-            memory_action::execute(agent, *action_name, *args);
+            memory_action::execute_v2(agent,agent_input, *action_name, *args);
         } else if (string_utils::starts_with(action_name, &b"response::")) {
             response_action::execute(agent, *action_name, *args);
         } else if (string_utils::starts_with(action_name, &b"transfer::")) {

--- a/nuwa-framework/sources/actions/memory_action.move
+++ b/nuwa-framework/sources/actions/memory_action.move
@@ -8,15 +8,18 @@ module nuwa_framework::memory_action {
     use nuwa_framework::agent::{Self, Agent};
     use nuwa_framework::memory;
     use nuwa_framework::action;
+    use nuwa_framework::address_utils;
 
-    /// Memory action names using namespaced format
-    const ACTION_NAME_ADD: vector<u8> = b"memory::add";
-    const ACTION_NAME_UPDATE: vector<u8> = b"memory::update";
+    /// Memory action names using more intuitive namespacing
+    const ACTION_NAME_REMEMBER_SELF: vector<u8> = b"memory::remember_self";
+    const ACTION_NAME_REMEMBER_USER: vector<u8> = b"memory::remember_user";
+    const ACTION_NAME_UPDATE_SELF: vector<u8> = b"memory::update_self";
+    const ACTION_NAME_UPDATE_USER: vector<u8> = b"memory::update_user";
     
     /// Special content to mark "deleted" memories
     const MEMORY_DELETED_MARK: vector<u8> = b"[deleted]";
 
-    ///TODO remove functions below
+    // Context constants - keeping these for backwards compatibility
     public fun context_personal(): String { memory::context_personal() }
     public fun context_interaction(): String { memory::context_interaction() }
     public fun context_knowledge(): String { memory::context_knowledge() }
@@ -26,11 +29,11 @@ module nuwa_framework::memory_action {
     public fun context_feedback(): String { memory::context_feedback() }
     public fun context_rule(): String { memory::context_rule() }
     
-    //TODO remove this function
     public fun is_valid_context(context: &String): bool {
         memory::is_standard_context(context)
     }
 
+    //TODO remove this
     #[data_struct]
     /// Arguments for the add memory action
     struct AddMemoryArgs has copy, drop {
@@ -41,6 +44,15 @@ module nuwa_framework::memory_action {
     }
 
     #[data_struct]
+    /// Arguments for adding a memory about oneself
+    struct RememberSelfArgs has copy, drop {
+        content: String,     // Memory content
+        context: String,     // Context tag for the memory
+        is_long_term: bool,  // Whether this is a long-term memory
+    }
+
+    //TODO Remove this
+    #[data_struct]
     /// Arguments for the update memory action
     struct UpdateMemoryArgs has copy, drop {
         target: address,     // Target address
@@ -50,6 +62,33 @@ module nuwa_framework::memory_action {
         is_long_term: bool,  // Whether this is a long-term memory
     }
 
+    #[data_struct]
+    /// Arguments for adding a memory about a user
+    struct RememberUserArgs has copy, drop {
+        content: String,     // Memory content
+        context: String,     // Context tag for the memory
+        is_long_term: bool,  // Whether this is a long-term memory
+    }
+
+    #[data_struct]
+    /// Arguments for updating a memory about oneself
+    struct UpdateSelfMemoryArgs has copy, drop {
+        index: u64,          // Memory index
+        new_content: String, // New memory content
+        new_context: String, // New context tag
+        is_long_term: bool,  // Whether this is a long-term memory
+    }
+
+    #[data_struct]
+    /// Arguments for updating a memory about a user
+    struct UpdateUserMemoryArgs has copy, drop {
+        index: u64,          // Memory index
+        new_content: String, // New memory content
+        new_context: String, // New context tag
+        is_long_term: bool,  // Whether this is a long-term memory
+    }
+
+    //TODO remove this
     /// Create arguments for add memory action
     public fun create_add_memory_args(
         target: address,
@@ -65,6 +104,7 @@ module nuwa_framework::memory_action {
         }
     }
 
+    //TODO remove this
     /// Create arguments for update memory action
     public fun create_update_memory_args(
         target: address,
@@ -82,149 +122,209 @@ module nuwa_framework::memory_action {
         }
     }
 
-    // Action examples
-    const ADD_MEMORY_EXAMPLE: vector<u8> = b"{\"target\":\"0x5e379ab70f1cc09b5d8e86a32833ccf5eddef0cb376402b5d0d4e9074eb16a4f\",\"content\":\"User prefers detailed explanations\",\"context\":\"preference\",\"is_long_term\":true}";
-    const UPDATE_MEMORY_EXAMPLE: vector<u8> = b"{\"target\":\"0x5e379ab70f1cc09b5d8e86a32833ccf5eddef0cb376402b5d0d4e9074eb16a4f\",\"index\":5,\"new_content\":\"User now prefers concise explanations\",\"new_context\":\"preference\",\"is_long_term\":true}";
+    // Action examples - simplified examples for better AI understanding
+    const REMEMBER_SELF_EXAMPLE: vector<u8> = b"{\"content\":\"I find that I connect well with users who share personal stories\",\"context\":\"personal\",\"is_long_term\":true}";
+    const REMEMBER_USER_EXAMPLE: vector<u8> = b"{\"content\":\"User prefers detailed technical explanations\",\"context\":\"preference\",\"is_long_term\":true}";
+    const UPDATE_SELF_EXAMPLE: vector<u8> = b"{\"index\":2,\"new_content\":\"I've noticed I'm more effective when I ask clarifying questions\",\"new_context\":\"personal\",\"is_long_term\":true}";
+    const UPDATE_USER_EXAMPLE: vector<u8> = b"{\"index\":3,\"new_content\":\"User now prefers concise explanations with code examples\",\"new_context\":\"preference\",\"is_long_term\":true}";
 
     public fun register_actions() {
-
-        // Register add_memory action
-        let add_memory_args = vector[
-            action::new_action_argument(
-                string::utf8(b"target"),
-                string::utf8(b"string"),
-                string::utf8(b"The address to store memory for (user address or yourself address)"),
-                true,
-            ),
+        // Register remember_self action (AI's memories about itself)
+        let remember_self_args = vector[
             action::new_action_argument(
                 string::utf8(b"content"),
                 string::utf8(b"string"),
-                string::utf8(b"The content of the memory"),
+                string::utf8(b"The content of your memory about yourself"),
                 true,
             ),
             action::new_action_argument(
                 string::utf8(b"context"),
                 string::utf8(b"string"),
-                string::utf8(b"The context tag for the memory"),
+                string::utf8(b"The context tag for your memory (personal, goal, etc.)"),
                 true,
             ),
             action::new_action_argument(
                 string::utf8(b"is_long_term"),
                 string::utf8(b"bool"),
-                string::utf8(b"Whether to store as long-term memory"),
+                string::utf8(b"Whether to store as a permanent memory"),
                 true,
             ),
         ];
 
         action::register_action(
-            string::utf8(ACTION_NAME_ADD),
-            string::utf8(b"Add a new memory about a user or yourself"),
-            add_memory_args,
-            string::utf8(ADD_MEMORY_EXAMPLE),
-            string::utf8(b"Use this to store important information about users or yourself"),
-            string::utf8(b""),
+            string::utf8(ACTION_NAME_REMEMBER_SELF),
+            string::utf8(b"Remember something about yourself"),
+            remember_self_args,
+            string::utf8(REMEMBER_SELF_EXAMPLE),
+            string::utf8(b"Use this to record your own thoughts, feelings, goals, or personal development"),
+            string::utf8(b"Self-memories help you maintain continuity of identity"),
         );
 
-        // Register update_memory action
-        let update_memory_args = vector[
+        // Register remember_user action (AI's memories about the user)
+        let remember_user_args = vector[
             action::new_action_argument(
-                string::utf8(b"target"),
-                string::utf8(b"address"),
-                string::utf8(b"The address whose memory to update"),
+                string::utf8(b"content"),
+                string::utf8(b"string"),
+                string::utf8(b"The content of your memory about the user"),
                 true,
             ),
             action::new_action_argument(
+                string::utf8(b"context"),
+                string::utf8(b"string"),
+                string::utf8(b"The context tag for your memory (preference, feedback, etc.)"),
+                true,
+            ),
+            action::new_action_argument(
+                string::utf8(b"is_long_term"),
+                string::utf8(b"bool"),
+                string::utf8(b"Whether to store as a permanent memory"),
+                true,
+            ),
+        ];
+
+        action::register_action(
+            string::utf8(ACTION_NAME_REMEMBER_USER),
+            string::utf8(b"Remember something about the current user"),
+            remember_user_args,
+            string::utf8(REMEMBER_USER_EXAMPLE),
+            string::utf8(b"Use this to record important information about the user you're speaking with"),
+            string::utf8(b"User memories help you personalize future interactions"),
+        );
+
+        // Register update_self action (updating AI's memories about itself)
+        let update_self_args = vector[
+            action::new_action_argument(
                 string::utf8(b"index"),
                 string::utf8(b"u64"),
-                string::utf8(b"The index of the memory to update"),
+                string::utf8(b"The index of your memory to update"),
                 true,
             ),
             action::new_action_argument(
                 string::utf8(b"new_content"),
                 string::utf8(b"string"),
-                string::utf8(b"The new content"),
+                string::utf8(b"The updated content"),
                 true,
             ),
             action::new_action_argument(
                 string::utf8(b"new_context"),
                 string::utf8(b"string"),
-                string::utf8(b"The new context for the memory"),
+                string::utf8(b"The updated context tag"),
                 true,
             ),
             action::new_action_argument(
                 string::utf8(b"is_long_term"),
                 string::utf8(b"bool"),
-                string::utf8(b"Whether to store as long-term memory"),
+                string::utf8(b"Whether to store as a permanent memory"),
                 true,
             ),
         ];
 
         action::register_action(
-            string::utf8(ACTION_NAME_UPDATE),
-            string::utf8(b"Update an existing memory"),
-            update_memory_args,
-            string::utf8(UPDATE_MEMORY_EXAMPLE),
-            string::utf8(b"Use this action to modify existing memories or mark them as deleted by setting content to '[deleted]'"),
-            string::utf8(b""),
+            string::utf8(ACTION_NAME_UPDATE_SELF),
+            string::utf8(b"Update a memory about yourself"),
+            update_self_args,
+            string::utf8(UPDATE_SELF_EXAMPLE),
+            string::utf8(b"Use this to modify your existing memories about yourself"),
+            string::utf8(b"Set content to '[deleted]' to mark a memory for deletion"),
+        );
+
+        // Register update_user action (updating AI's memories about the user)
+        let update_user_args = vector[
+            action::new_action_argument(
+                string::utf8(b"index"),
+                string::utf8(b"u64"),
+                string::utf8(b"The index of the user memory to update"),
+                true,
+            ),
+            action::new_action_argument(
+                string::utf8(b"new_content"),
+                string::utf8(b"string"),
+                string::utf8(b"The updated content"),
+                true,
+            ),
+            action::new_action_argument(
+                string::utf8(b"new_context"),
+                string::utf8(b"string"),
+                string::utf8(b"The updated context tag"),
+                true,
+            ),
+            action::new_action_argument(
+                string::utf8(b"is_long_term"),
+                string::utf8(b"bool"),
+                string::utf8(b"Whether to store as a permanent memory"),
+                true,
+            ),
+        ];
+
+        action::register_action(
+            string::utf8(ACTION_NAME_UPDATE_USER),
+            string::utf8(b"Update a memory about the current user"),
+            update_user_args,
+            string::utf8(UPDATE_USER_EXAMPLE),
+            string::utf8(b"Use this to modify your existing memories about the user"),
+            string::utf8(b"Set content to '[deleted]' to mark a memory for deletion"),
         );
     }
 
     /// Execute memory actions
     public fun execute(agent: &mut Object<Agent>, action_name: String, args_json: String) {
-        if (action_name == string::utf8(ACTION_NAME_ADD)) {
-            let args_opt = json::from_json_option<AddMemoryArgs>(string::into_bytes(args_json));
+        let agent_address = agent::get_agent_address(agent);
+        let store = agent::borrow_mut_memory_store(agent);
+        
+        if (action_name == string::utf8(ACTION_NAME_REMEMBER_SELF)) {
+            // Add memory about self
+            let args_opt = json::from_json_option<RememberSelfArgs>(string::into_bytes(args_json));
             if (!option::is_some(&args_opt)) {
-                std::debug::print(&string::utf8(b"Invalid arguments for action"));
+                std::debug::print(&string::utf8(b"Invalid arguments for remember_self action"));
                 return
             };
             let args = option::destroy_some(args_opt);
-            let store = agent::borrow_mut_memory_store(agent);
-            memory::add_memory(store, args.target, args.content, args.context, args.is_long_term);
-        } else if (action_name == string::utf8(ACTION_NAME_UPDATE)) {
-            let args_opt = json::from_json_option<UpdateMemoryArgs>(string::into_bytes(args_json));
+            memory::add_memory(store, agent_address, args.content, args.context, args.is_long_term);
+        } 
+        else if (action_name == string::utf8(ACTION_NAME_REMEMBER_USER)) {
+            // Add memory about current user
+            let args_opt = json::from_json_option<RememberUserArgs>(string::into_bytes(args_json));
             if (!option::is_some(&args_opt)) {
-                std::debug::print(&string::utf8(b"Invalid arguments for action"));
+                std::debug::print(&string::utf8(b"Invalid arguments for remember_user action"));
                 return
             };
             let args = option::destroy_some(args_opt);
-            let store = agent::borrow_mut_memory_store(agent);
+            let current_user = agent::get_current_user(agent);
+            memory::add_memory(store, current_user, args.content, args.context, args.is_long_term);
+        }
+        else if (action_name == string::utf8(ACTION_NAME_UPDATE_SELF)) {
+            // Update memory about self
+            let args_opt = json::from_json_option<UpdateSelfMemoryArgs>(string::into_bytes(args_json));
+            if (!option::is_some(&args_opt)) {
+                std::debug::print(&string::utf8(b"Invalid arguments for update_self action"));
+                return
+            };
+            let args = option::destroy_some(args_opt);
             memory::update_memory(
                 store,
-                args.target,
+                agent_address,
                 args.index,
                 args.new_content,
                 option::some(args.new_context),
                 args.is_long_term
             );
-        };
-    }
-
-    /// Helper function to update memory
-    fun update_memory(
-        store: &mut memory::MemoryStore,
-        user: address,
-        old_content: String,
-        new_content: String,
-        context: String,
-        is_long_term: bool,
-    ) {
-        let index_opt = memory::find_memory_index(
-            store,
-            user,
-            &old_content,
-            &context,
-            is_long_term
-        );
-        
-        if (option::is_some(&index_opt)) {
-            let index = option::destroy_some(index_opt);
+        }
+        else if (action_name == string::utf8(ACTION_NAME_UPDATE_USER)) {
+            // Update memory about current user
+            let args_opt = json::from_json_option<UpdateUserMemoryArgs>(string::into_bytes(args_json));
+            if (!option::is_some(&args_opt)) {
+                std::debug::print(&string::utf8(b"Invalid arguments for update_user action"));
+                return
+            };
+            let args = option::destroy_some(args_opt);
+            let current_user = agent::get_current_user(agent);
             memory::update_memory(
                 store,
-                user,
-                index,
-                new_content,
-                option::some(context),
-                is_long_term
+                current_user,
+                args.index,
+                args.new_content,
+                option::some(args.new_context),
+                args.is_long_term
             );
         };
     }
@@ -236,44 +336,82 @@ module nuwa_framework::memory_action {
         action::init_for_test();
         register_actions();
 
-        let (agent, cap) = agent::create_test_agent();
+        let (agent_obj, cap) = agent::create_test_agent();
         let test_addr = @0x42;
         
-        // Test add memory
-        let add_args_json = string::utf8(b"{\"target\":\"0x42\",\"content\":\"User likes detailed explanations\",\"context\":\"preference\",\"is_long_term\":true}");
-        execute(agent, string::utf8(ACTION_NAME_ADD), add_args_json);
-
-        // Test update memory
-        let update_args_json = string::utf8(b"{\"target\":\"0x42\",\"index\":0,\"new_content\":\"User prefers comprehensive explanations\",\"new_context\":\"preference\",\"is_long_term\":true}");
-        execute(agent, string::utf8(ACTION_NAME_UPDATE), update_args_json);
+        // Set the current user for the agent
+        agent::set_current_user(agent_obj, test_addr);
         
-        // Verify the update
-        let store = agent::borrow_memory_store(agent);
-        let memories = memory::get_context_memories(store, test_addr);
-        assert!(vector::length(&memories) == 1, 1);
-        let updated_memory = vector::borrow(&memories, 0);
-        assert!(memory::get_content(updated_memory) == string::utf8(b"User prefers comprehensive explanations"), 2);
+        // Test remember_self action
+        let remember_self_json = string::utf8(b"{\"content\":\"I enjoy helping with technical explanations\",\"context\":\"personal\",\"is_long_term\":true}");
+        execute(agent_obj, string::utf8(ACTION_NAME_REMEMBER_SELF), remember_self_json);
+
+        // Test remember_user action
+        let remember_user_json = string::utf8(b"{\"content\":\"User likes detailed explanations\",\"context\":\"preference\",\"is_long_term\":true}");
+        execute(agent_obj, string::utf8(ACTION_NAME_REMEMBER_USER), remember_user_json);
+        
+        // Verify self memory
+        let store = agent::borrow_memory_store(agent_obj);
+        let self_memories = memory::get_self_memories(store);
+        assert!(vector::length(&self_memories) == 1, 1);
+        let self_memory = vector::borrow(&self_memories, 0);
+        assert!(memory::get_content(self_memory) == string::utf8(b"I enjoy helping with technical explanations"), 2);
+        
+        // Verify user memory
+        let user_memories = memory::get_context_memories(store, test_addr);
+        assert!(vector::length(&user_memories) == 1, 3);
+        let user_memory = vector::borrow(&user_memories, 0);
+        assert!(memory::get_content(user_memory) == string::utf8(b"User likes detailed explanations"), 4);
+        
+        // Test update_self action
+        let update_self_json = string::utf8(b"{\"index\":0,\"new_content\":\"I find I'm most effective when providing code examples\",\"new_context\":\"personal\",\"is_long_term\":true}");
+        execute(agent_obj, string::utf8(ACTION_NAME_UPDATE_SELF), update_self_json);
+        
+        // Test update_user action
+        let update_user_json = string::utf8(b"{\"index\":0,\"new_content\":\"User now prefers concise explanations\",\"new_context\":\"preference\",\"is_long_term\":true}");
+        execute(agent_obj, string::utf8(ACTION_NAME_UPDATE_USER), update_user_json);
+        
+        // Verify updated memories
+        store = agent::borrow_memory_store(agent_obj);
+        self_memories = memory::get_self_memories(store);
+        let updated_self_memory = vector::borrow(&self_memories, 0);
+        assert!(memory::get_content(updated_self_memory) == string::utf8(b"I find I'm most effective when providing code examples"), 5);
+        
+        user_memories = memory::get_context_memories(store, test_addr);
+        let updated_user_memory = vector::borrow(&user_memories, 0);
+        assert!(memory::get_content(updated_user_memory) == string::utf8(b"User now prefers concise explanations"), 6);
         
         agent::destroy_agent_cap(cap);
     }
 
     #[test]
     fun test_memory_action_examples() {
-        // Test add memory example
-        let add_args = json::from_json<AddMemoryArgs>(ADD_MEMORY_EXAMPLE);
-        assert!(add_args.target == @0x5e379ab70f1cc09b5d8e86a32833ccf5eddef0cb376402b5d0d4e9074eb16a4f, 1);
-        assert!(add_args.content == string::utf8(b"User prefers detailed explanations"), 2);
-        assert!(add_args.context == string::utf8(b"preference"), 3);
-        assert!(add_args.is_long_term == true, 4);
-        assert!(memory::is_standard_context(&add_args.context), 5);
+        // Test remember_self example
+        let self_args = json::from_json<RememberSelfArgs>(REMEMBER_SELF_EXAMPLE);
+        assert!(self_args.content == string::utf8(b"I find that I connect well with users who share personal stories"), 1);
+        assert!(self_args.context == string::utf8(b"personal"), 2);
+        assert!(self_args.is_long_term == true, 3);
+        assert!(memory::is_standard_context(&self_args.context), 4);
 
-        // Test update memory example
-        let update_args = json::from_json<UpdateMemoryArgs>(UPDATE_MEMORY_EXAMPLE);
-        assert!(update_args.target == @0x5e379ab70f1cc09b5d8e86a32833ccf5eddef0cb376402b5d0d4e9074eb16a4f, 6);
-        assert!(update_args.index == 5, 7);
-        assert!(update_args.new_content == string::utf8(b"User now prefers concise explanations"), 8);
-        assert!(update_args.new_context == string::utf8(b"preference"), 9);
-        assert!(update_args.is_long_term == true, 10);
-        assert!(memory::is_standard_context(&update_args.new_context), 11);
+        // Test remember_user example
+        let user_args = json::from_json<RememberUserArgs>(REMEMBER_USER_EXAMPLE);
+        assert!(user_args.content == string::utf8(b"User prefers detailed technical explanations"), 5);
+        assert!(user_args.context == string::utf8(b"preference"), 6);
+        assert!(user_args.is_long_term == true, 7);
+        assert!(memory::is_standard_context(&user_args.context), 8);
+
+        // Test update_self example
+        let update_self_args = json::from_json<UpdateSelfMemoryArgs>(UPDATE_SELF_EXAMPLE);
+        assert!(update_self_args.index == 2, 9);
+        assert!(update_self_args.new_content == string::utf8(b"I've noticed I'm more effective when I ask clarifying questions"), 10);
+        assert!(update_self_args.new_context == string::utf8(b"personal"), 11);
+        assert!(update_self_args.is_long_term == true, 12);
+
+        // Test update_user example
+        let update_user_args = json::from_json<UpdateUserMemoryArgs>(UPDATE_USER_EXAMPLE);
+        assert!(update_user_args.index == 3, 13);
+        assert!(update_user_args.new_content == string::utf8(b"User now prefers concise explanations with code examples"), 14);
+        assert!(update_user_args.new_context == string::utf8(b"preference"), 15);
+        assert!(update_user_args.is_long_term == true, 16);
     }
 }

--- a/nuwa-framework/sources/actions/response_action.move
+++ b/nuwa-framework/sources/actions/response_action.move
@@ -1,12 +1,14 @@
 module nuwa_framework::response_action {
     use std::string::{Self, String};
     use std::option;
+    use std::vector;
     use moveos_std::object::{Self, Object, ObjectID};
     use moveos_std::json;
     use nuwa_framework::agent::{Self, Agent};
     use nuwa_framework::action;
     use nuwa_framework::channel;
     use nuwa_framework::string_utils::{channel_id_to_string, string_to_channel_id};
+    use nuwa_framework::action::ActionDescription;
 
     const ACTION_NAME_SAY: vector<u8> = b"response::say";
     // Action example
@@ -32,6 +34,11 @@ module nuwa_framework::response_action {
     }
 
     public fun register_actions() {
+    }
+
+    public fun get_action_descriptions() : vector<ActionDescription> {
+        let descriptions = vector::empty();
+
         // Register say action with channel_id parameter
         let say_args = vector[
             action::new_action_argument(
@@ -48,14 +55,17 @@ module nuwa_framework::response_action {
             ),
         ];
 
-        action::register_action(
-            string::utf8(ACTION_NAME_SAY),
-            string::utf8(b"Send a response to the user"),
-            say_args,
-            string::utf8(SAY_ACTION_EXAMPLE),
-            string::utf8(b"Use this action to send your final response to the specified channel"),
-            string::utf8(b"Must be used exactly once in each response"),
+        vector::push_back(&mut descriptions,
+            action::new_action_description(
+                string::utf8(ACTION_NAME_SAY),
+                string::utf8(b"Send a response to the user"),
+                say_args,
+                string::utf8(SAY_ACTION_EXAMPLE),
+                string::utf8(b"Use this action to send your final response to the specified channel"),
+                string::utf8(b"Must be used exactly once in each response"),
+            )
         );
+        descriptions
     }
 
     public fun execute(agent: &mut Object<Agent>, action_name: String, args_json: String) {

--- a/nuwa-framework/sources/actions/transfer_action.move
+++ b/nuwa-framework/sources/actions/transfer_action.move
@@ -1,4 +1,5 @@
 module nuwa_framework::transfer_action {
+    use std::vector;
     use std::string::{Self, String};
     use std::option;
     use moveos_std::object::{Object};
@@ -7,7 +8,7 @@ module nuwa_framework::transfer_action {
     use rooch_framework::transfer;
     use rooch_framework::gas_coin::RGas;
     use nuwa_framework::agent::{Self, Agent};
-    use nuwa_framework::action;
+    use nuwa_framework::action::{Self, ActionDescription};
 
     // Action names
     const ACTION_NAME_TRANSFER: vector<u8> = b"transfer::coin";
@@ -25,6 +26,14 @@ module nuwa_framework::transfer_action {
 
     /// Register all transfer-related actions
     public fun register_actions() {
+    }
+
+    entry fun register_actions_entry() {
+        register_actions();
+    }
+
+    public fun get_action_descriptions() : vector<ActionDescription> {
+        let descriptions = vector::empty();
         // Register transfer coin action
         let transfer_args = vector[
             action::new_action_argument(
@@ -52,20 +61,17 @@ module nuwa_framework::transfer_action {
                 true,
             ),
         ];
-
-        action::register_action(
+        vector::push_back(&mut descriptions, action::new_action_description(
             string::utf8(ACTION_NAME_TRANSFER),
             string::utf8(b"Transfer coin_type coins to an address"),
             transfer_args,
             string::utf8(TRANSFER_ACTION_EXAMPLE),
             string::utf8(b"Use this action to transfer coin_type coins from your account to another address"),
             string::utf8(b"Transfers will be executed immediately and are irreversible"),
-        );
+        ));
+        descriptions
     }
-
-    entry fun register_actions_entry() {
-        register_actions();
-    }
+    
 
     /// Execute a transfer action
     public fun execute(agent: &mut Object<Agent>, action_name: String, args_json: String) {

--- a/nuwa-framework/sources/agent.move
+++ b/nuwa-framework/sources/agent.move
@@ -215,20 +215,6 @@ module nuwa_framework::agent {
         agent_ref.last_active_timestamp = timestamp::now_milliseconds();
     }
 
-    // =============== Agent Info functions ===============
-
-    public fun agent_info_name(agent_info: &AgentInfo): &String {
-        &agent_info.name
-    }
-
-    public fun agent_info_username(agent_info: &AgentInfo): &String {
-        &agent_info.username
-    }
-
-    public fun agent_info_agent_address(agent_info: &AgentInfo): address {
-        agent_info.agent_address
-    }
-
 
     #[test_only]
     /// Create a test agent for unit testing

--- a/nuwa-framework/sources/agent.move
+++ b/nuwa-framework/sources/agent.move
@@ -1,6 +1,5 @@
 module nuwa_framework::agent {
     use std::string::{Self, String};
-    use std::vector;
     use moveos_std::object::{Self, Object, ObjectID};
     use moveos_std::account::{Self, Account};
     use moveos_std::signer;
@@ -8,9 +7,9 @@ module nuwa_framework::agent {
     use nuwa_framework::character::{Self, Character};
     use nuwa_framework::agent_cap::{Self, AgentCap};
     use nuwa_framework::memory::{Self, MemoryStore};
-    use nuwa_framework::action::{Self, ActionDescription};
     use nuwa_framework::agent_input::{AgentInput};
-    use nuwa_framework::agent_state::{Self, AgentStates};
+    use nuwa_framework::agent_state::{AgentStates};
+    use nuwa_framework::agent_info;
 
     friend nuwa_framework::memory_action;
     friend nuwa_framework::transfer_action;
@@ -31,7 +30,7 @@ module nuwa_framework::agent {
         model_provider: String,
     }
 
-    //TODO add model_provider to AgentInfo
+    //TODO remove this after
     struct AgentInfo has copy, drop, store {
         id: ObjectID,
         name: String,            
@@ -99,11 +98,6 @@ module nuwa_framework::agent {
         abort ErrorDeprecatedFunction
     }
 
-    // Helper function to get available actions
-    fun get_available_actions<I: drop>(_input: &AgentInput<I>): vector<ActionDescription> {
-        action::get_all_action_descriptions()
-    }
-
     public fun borrow_mut_agent(agent_obj_id: ObjectID): &mut Object<Agent> {
         object::borrow_mut_object_shared(agent_obj_id)
     }
@@ -137,6 +131,22 @@ module nuwa_framework::agent {
             bio: *character::get_bio(character),
             knowledge: *character::get_knowledge(character),
         }
+    }
+
+    public fun get_agent_info_v2(agent: &Object<Agent>): agent_info::AgentInfo {
+        let agent_ref = object::borrow(agent);
+        let character = object::borrow(&agent_ref.character);
+        agent_info::new_agent_info(
+            object::id(agent),
+            *character::get_name(character),
+            *character::get_username(character),
+            string::utf8(b""),
+            agent_ref.agent_address,
+            *character::get_description(character),
+            *character::get_bio(character),
+            *character::get_knowledge(character),
+            agent_ref.model_provider,
+        )
     }
 
     public fun get_agent_info_by_address(agent_addr: address): AgentInfo {

--- a/nuwa-framework/sources/agent_info.move
+++ b/nuwa-framework/sources/agent_info.move
@@ -1,7 +1,8 @@
 module nuwa_framework::agent_info {
     use std::string::{Self, String};
     use std::vector;
-    use moveos_std::object::{Self, ObjectID};
+    use moveos_std::json;
+    use moveos_std::object::{ObjectID};
 
     #[data_struct]
     struct AgentInfo has copy, drop, store {
@@ -77,13 +78,32 @@ module nuwa_framework::agent_info {
         &agent_info.model_provider
     }
 
+    /// The PromptAgentInfo struct is used to display agent information in a prompt
+    struct PromptAgentInfo has copy, drop, store {
+        name: String,            
+        username: String,
+        avatar: String,        
+        agent_address: address,  // AI's agent address
+        description: String,
+        bio: vector<String>,
+        knowledge: vector<String>,
+        model_provider: String,
+    }
 
     public fun to_prompt(agent_info: &AgentInfo): String {
-        let prompt = string::utf8(b"");
-        string::append(&mut prompt, &agent_info.name);
-        string::append(&mut prompt, string::utf8(b" ("));
-        string::append(&mut prompt, &agent_info.username);
-        string::append(&mut prompt, string::utf8(b")"));
-        prompt
+        let prompt_agent_info = PromptAgentInfo {
+            name: agent_info.name,
+            username: agent_info.username,
+            avatar: agent_info.avatar,
+            agent_address: agent_info.agent_address,
+            description: agent_info.description,
+            bio: agent_info.bio,
+            knowledge: agent_info.knowledge,
+            model_provider: agent_info.model_provider,
+        };
+        let prompt = b"```json\n";
+        vector::append(&mut prompt, json::to_json(&prompt_agent_info));
+        vector::append(&mut prompt, b"\n```");
+        string::utf8(prompt)
     }
 }

--- a/nuwa-framework/sources/agent_info.move
+++ b/nuwa-framework/sources/agent_info.move
@@ -1,0 +1,89 @@
+module nuwa_framework::agent_info {
+    use std::string::{Self, String};
+    use std::vector;
+    use moveos_std::object::{Self, ObjectID};
+
+    #[data_struct]
+    struct AgentInfo has copy, drop, store {
+        id: ObjectID,
+        name: String,            
+        username: String,
+        avatar: String,        
+        agent_address: address,  // AI's agent address
+        description: String,
+        bio: vector<String>,
+        knowledge: vector<String>,
+        model_provider: String,
+    }
+
+    public fun new_agent_info(
+        id: ObjectID,
+        name: String,
+        username: String,
+        avatar: String,
+        agent_address: address,
+        description: String,
+        bio: vector<String>,
+        knowledge: vector<String>,
+        model_provider: String,
+    ): AgentInfo {
+        AgentInfo {
+            id,
+            name,
+            username,
+            avatar,
+            agent_address,
+            description,
+            bio,
+            knowledge,
+            model_provider,
+        }
+    }
+
+    // ============ Getters ============
+    public fun get_id(agent_info: &AgentInfo): ObjectID {
+        agent_info.id
+    }
+
+    public fun get_name(agent_info: &AgentInfo): &String {
+        &agent_info.name
+    }
+
+    public fun get_username(agent_info: &AgentInfo): &String {
+        &agent_info.username
+    }
+
+    public fun get_avatar(agent_info: &AgentInfo): &String {
+        &agent_info.avatar
+    }
+
+    public fun get_agent_address(agent_info: &AgentInfo): address {
+        agent_info.agent_address
+    }
+
+    public fun get_description(agent_info: &AgentInfo): &String {
+        &agent_info.description
+    }
+
+    public fun get_bio(agent_info: &AgentInfo): &vector<String> {
+        &agent_info.bio
+    }
+
+    public fun get_knowledge(agent_info: &AgentInfo): &vector<String> {
+        &agent_info.knowledge
+    }
+
+    public fun get_model_provider(agent_info: &AgentInfo): &String {
+        &agent_info.model_provider
+    }
+
+
+    public fun to_prompt(agent_info: &AgentInfo): String {
+        let prompt = string::utf8(b"");
+        string::append(&mut prompt, &agent_info.name);
+        string::append(&mut prompt, string::utf8(b" ("));
+        string::append(&mut prompt, &agent_info.username);
+        string::append(&mut prompt, string::utf8(b")"));
+        prompt
+    }
+}

--- a/nuwa-framework/sources/agent_input.move
+++ b/nuwa-framework/sources/agent_input.move
@@ -1,5 +1,6 @@
 module nuwa_framework::agent_input{
-    use std::string::String;
+    use std::string::{Self, String};
+    use moveos_std::json;
     
     struct AgentInput<I> has copy, drop, store {
         sender: address,
@@ -7,6 +8,10 @@ module nuwa_framework::agent_input{
         input_data: I,
     }
 
+    struct AgentInputInfo has copy, drop, store {
+        sender: address,
+        input_data_json: String,
+    }
 
     public fun new_agent_input<I>(
         sender: address,
@@ -35,5 +40,20 @@ module nuwa_framework::agent_input{
     public fun unpack<I>(input: AgentInput<I>) : (address, String, I) {
         let AgentInput { sender, input_description, input_data } = input;
         (sender, input_description, input_data)
+    }
+
+    public fun to_agent_input_info<I>(input: &AgentInput<I>) : AgentInputInfo {
+        AgentInputInfo {
+            sender: input.sender,
+            input_data_json: string::utf8(json::to_json(&input.input_data)),
+        }
+    }
+
+    public fun get_sender_from_info(info: &AgentInputInfo): address {
+        info.sender
+    }
+
+    public fun get_input_data_from_info(info: &AgentInputInfo): &String {
+        &info.input_data_json
     }
 }

--- a/nuwa-framework/sources/agent_input.move
+++ b/nuwa-framework/sources/agent_input.move
@@ -56,4 +56,12 @@ module nuwa_framework::agent_input{
     public fun get_input_data_from_info(info: &AgentInputInfo): &String {
         &info.input_data_json
     }
+
+    #[test_only]
+    public fun new_agent_input_info_for_test(sender: address, input_data_json: String) : AgentInputInfo {
+        AgentInputInfo {
+            sender,
+            input_data_json,
+        }
+    }
 }

--- a/nuwa-framework/sources/agent_runner.move
+++ b/nuwa-framework/sources/agent_runner.move
@@ -1,30 +1,31 @@
 module nuwa_framework::agent_runner {
 
-    use std::string::{Self, String};
+    use std::string::{String};
     use std::vector;
-    use moveos_std::object::{Self, Object, ObjectID};
-    use moveos_std::signer;
-    use moveos_std::timestamp;
+    use moveos_std::object::{Self, Object};
 
-    use nuwa_framework::character::{Self, Character};
-    use nuwa_framework::agent_cap::{Self, AgentCap};
-    use nuwa_framework::memory::{Self, MemoryStore};
-    use nuwa_framework::action::{Self, ActionDescription};
-    use nuwa_framework::agent_input::{AgentInput};
-    use nuwa_framework::agent_state::{Self, AgentStates};
+    use rooch_framework::coin::{Self, Coin};
+    use rooch_framework::gas_coin::RGas;
+
+    use nuwa_framework::action::{ActionDescription};
+    use nuwa_framework::agent_input::{Self, AgentInput};
+    use nuwa_framework::agent_state::{AgentStates};
     use nuwa_framework::ai_request;
     use nuwa_framework::ai_service;
     use nuwa_framework::prompt_builder;
     use nuwa_framework::agent::{Self, Agent};
+    use nuwa_framework::action_dispatcher;
+    use nuwa_framework::state_providers;
+
 
     public fun generate_system_prompt<I: copy + drop>(
         agent: &Object<Agent>,
         states: AgentStates,
         input: AgentInput<I>,
     ): String {
-        let character = object::borrow(&agent.character);
-        let available_actions = agent::get_available_actions(&input);
-        let agent_info = agent::get_agent_info(agent);
+
+        let available_actions = get_available_actions(&input);
+        let agent_info = agent::get_agent_info_v2(agent);
         let memory_store = agent::borrow_memory_store(agent);
         prompt_builder::build_complete_prompt_v3(
             agent_info,
@@ -44,8 +45,9 @@ module nuwa_framework::agent_runner {
         //keep a fee argument for future usage.
         coin::destroy_zero(fee);
         let agent_id = object::id(agent_obj);
-        let model_provider = agent::get_agent_model_provider(agent_obj);
-        
+        let model_provider = *agent::get_agent_model_provider(agent_obj);
+        let states = state_providers::build_agent_state(agent_obj);
+        let input_info = agent_input::to_agent_input_info(&input);
         // Generate system prompt with context
         let system_prompt = generate_system_prompt(
             agent_obj,
@@ -66,8 +68,12 @@ module nuwa_framework::agent_runner {
         );
 
         // Call AI service
-        ai_service::request_ai(caller, agent_id, chat_request);
+        ai_service::request_ai(caller, agent_id, input_info, chat_request);
 
         agent::update_last_active_timestamp(agent_obj);
+    }
+
+    fun get_available_actions<I: drop>(_input: &AgentInput<I>): vector<ActionDescription> {
+        action_dispatcher::get_action_descriptions()
     }
 }

--- a/nuwa-framework/sources/agent_runner.move
+++ b/nuwa-framework/sources/agent_runner.move
@@ -21,7 +21,7 @@ module nuwa_framework::agent_runner {
         agent: &Object<Agent>,
         input: AgentInput<I>,
     ): String {
-        let states = state_providers::build_agent_state(agent);
+        let states = state_providers::get_agent_state(agent);
         std::debug::print(&states);
         let available_actions = get_available_actions(&input);
         let agent_info = agent::get_agent_info_v2(agent);

--- a/nuwa-framework/sources/agent_runner.move
+++ b/nuwa-framework/sources/agent_runner.move
@@ -1,0 +1,73 @@
+module nuwa_framework::agent_runner {
+
+    use std::string::{Self, String};
+    use std::vector;
+    use moveos_std::object::{Self, Object, ObjectID};
+    use moveos_std::signer;
+    use moveos_std::timestamp;
+
+    use nuwa_framework::character::{Self, Character};
+    use nuwa_framework::agent_cap::{Self, AgentCap};
+    use nuwa_framework::memory::{Self, MemoryStore};
+    use nuwa_framework::action::{Self, ActionDescription};
+    use nuwa_framework::agent_input::{AgentInput};
+    use nuwa_framework::agent_state::{Self, AgentStates};
+    use nuwa_framework::ai_request;
+    use nuwa_framework::ai_service;
+    use nuwa_framework::prompt_builder;
+    use nuwa_framework::agent::{Self, Agent};
+
+    public fun generate_system_prompt<I: copy + drop>(
+        agent: &Object<Agent>,
+        states: AgentStates,
+        input: AgentInput<I>,
+    ): String {
+        let character = object::borrow(&agent.character);
+        let available_actions = agent::get_available_actions(&input);
+        let agent_info = agent::get_agent_info(agent);
+        let memory_store = agent::borrow_memory_store(agent);
+        prompt_builder::build_complete_prompt_v3(
+            agent_info,
+            memory_store,
+            input,
+            available_actions,
+            states,
+        )
+    }
+
+    public fun process_input<I: copy + drop>(
+        caller: &signer,
+        agent_obj: &mut Object<Agent>,
+        input: AgentInput<I>,
+        fee: Coin<RGas>,
+    ) {
+        //keep a fee argument for future usage.
+        coin::destroy_zero(fee);
+        let agent_id = object::id(agent_obj);
+        let model_provider = agent::get_agent_model_provider(agent_obj);
+        
+        // Generate system prompt with context
+        let system_prompt = generate_system_prompt(
+            agent_obj,
+            states,
+            input
+        );
+
+        // Create chat messages
+        let messages = vector::empty();
+        
+        // Add system message
+        vector::push_back(&mut messages, ai_request::new_system_chat_message(system_prompt));
+
+        // Create chat request
+        let chat_request = ai_request::new_chat_request(
+            model_provider,
+            messages,
+        );
+
+        // Call AI service
+        ai_service::request_ai(caller, agent_id, chat_request);
+
+        agent::update_last_active_timestamp(agent_obj);
+    }
+}

--- a/nuwa-framework/sources/agent_runner.move
+++ b/nuwa-framework/sources/agent_runner.move
@@ -9,7 +9,6 @@ module nuwa_framework::agent_runner {
 
     use nuwa_framework::action::{ActionDescription};
     use nuwa_framework::agent_input::{Self, AgentInput};
-    use nuwa_framework::agent_state::{AgentStates};
     use nuwa_framework::ai_request;
     use nuwa_framework::ai_service;
     use nuwa_framework::prompt_builder;
@@ -20,10 +19,10 @@ module nuwa_framework::agent_runner {
 
     public fun generate_system_prompt<I: copy + drop>(
         agent: &Object<Agent>,
-        states: AgentStates,
         input: AgentInput<I>,
     ): String {
-
+        let states = state_providers::build_agent_state(agent);
+        std::debug::print(&states);
         let available_actions = get_available_actions(&input);
         let agent_info = agent::get_agent_info_v2(agent);
         let memory_store = agent::borrow_memory_store(agent);
@@ -46,12 +45,11 @@ module nuwa_framework::agent_runner {
         coin::destroy_zero(fee);
         let agent_id = object::id(agent_obj);
         let model_provider = *agent::get_agent_model_provider(agent_obj);
-        let states = state_providers::build_agent_state(agent_obj);
+        
         let input_info = agent_input::to_agent_input_info(&input);
         // Generate system prompt with context
         let system_prompt = generate_system_prompt(
             agent_obj,
-            states,
             input
         );
 

--- a/nuwa-framework/sources/ai_callback.move
+++ b/nuwa-framework/sources/ai_callback.move
@@ -15,10 +15,10 @@ module nuwa_framework::ai_callback {
 
     /// AI Oracle response processing callback, this function must be entry and no arguments
     public entry fun process_response() {
-        let pending_requests = ai_service::get_pending_requests();
+        let pending_requests = ai_service::get_pending_requests_v2();
         
         vector::for_each(pending_requests, |pending_request| {
-            let (request_id, agent_id) = ai_service::unpack_pending_request(pending_request);
+            let (request_id, agent_id, agent_input_info) = ai_service::unpack_pending_request_v2(pending_request);
             let response_status = oracles::get_response_status(&request_id);
             
             if (response_status != 0) {
@@ -38,7 +38,7 @@ module nuwa_framework::ai_callback {
                         let message_content = ai_response::get_message_content(&chat_completion);
 
                         let agent = object::borrow_mut_object_shared<Agent>(agent_id);
-                        action_dispatcher::dispatch_actions(agent, message_content);
+                        action_dispatcher::dispatch_actions_v2(agent, agent_input_info, message_content);
                         let refusal = ai_response::get_refusal(&chat_completion);
                         if(option::is_some(&refusal)){
                             let refusal_reason = option::destroy_some(refusal);

--- a/nuwa-framework/sources/chat/channel_entry.move
+++ b/nuwa-framework/sources/chat/channel_entry.move
@@ -2,10 +2,12 @@ module nuwa_framework::channel_entry {
     use std::vector;
     use std::string::String;
     use moveos_std::object::Object;
+    use rooch_framework::coin;
+    use rooch_framework::gas_coin::RGas;
     use nuwa_framework::message;
     use nuwa_framework::channel::{Self, Channel};
     use nuwa_framework::agent;
-    use nuwa_framework::state_providers;
+    use nuwa_framework::agent_runner;
 
     /// Send a message and trigger AI response if needed
     public entry fun send_message(
@@ -29,8 +31,8 @@ module nuwa_framework::channel_entry {
             let message_input = message::new_agent_input(messages);
             vector::for_each(mentioned_ai_agents, |ai_addr| {
                 let agent = agent::borrow_mut_agent_by_address(ai_addr);
-                let states = state_providers::build_agent_state(agent);
-                agent::process_input_v2(caller, agent, states, message_input);
+                let fee = coin::zero<RGas>();
+                agent_runner::process_input(caller, agent, message_input, fee);
             });
         }
     }

--- a/nuwa-framework/sources/prompt_builder.move
+++ b/nuwa-framework/sources/prompt_builder.move
@@ -42,23 +42,34 @@ module nuwa_framework::prompt_builder {
     }
 
     public fun build_complete_prompt<D: drop>(
-        agent_address: address,
-        character: &Character,
-        memory_store: &MemoryStore,
-        input: AgentInput<D>,
-        available_actions: vector<ActionDescription>,
+        _agent_address: address,
+        _character: &Character,
+        _memory_store: &MemoryStore,
+        _input: AgentInput<D>,
+        _available_actions: vector<ActionDescription>,
     ): String {
-        build_complete_prompt_v2(agent_address, character, memory_store, input, available_actions, agent_state::new_agent_states())
+        abort 0
     }
 
     public(friend) fun build_complete_prompt_v2<D: drop>(
-        agent_address: address,
-        character: &Character,
+        _agent_address: address,
+        _character: &Character,
+        _memory_store: &MemoryStore,
+        _input: AgentInput<D>,
+        _available_actions: vector<ActionDescription>,
+        _agent_states: AgentStates,
+    ): String {
+        abrot 0
+    }
+
+    public(friend) fun build_complete_prompt_v3<D: drop>(
+        agent_info: &AgentInfo,
         memory_store: &MemoryStore,
         input: AgentInput<D>,
         available_actions: vector<ActionDescription>,
         agent_states: AgentStates,
     ): String {
+        let agent_address = agent::agent_info_
         let (user, input_description, input_data) = agent_input::unpack(input);
         let prompt = string::utf8(b"## Nuwa AI Entity - Core Directives\n\n");
     

--- a/nuwa-framework/sources/prompt_builder.move
+++ b/nuwa-framework/sources/prompt_builder.move
@@ -7,9 +7,11 @@ module nuwa_framework::prompt_builder {
     use nuwa_framework::action::{ActionDescription};
     use nuwa_framework::agent_input::{Self, AgentInput};
     use nuwa_framework::address_utils::{address_to_string};
-    use nuwa_framework::agent_state::{Self, AgentStates};
+    use nuwa_framework::agent_state::{AgentStates};
+    use nuwa_framework::agent_info::{Self, AgentInfo};
 
     friend nuwa_framework::agent;
+    friend nuwa_framework::agent_runner;
 
     /// Data structures for JSON serialization
     struct CharacterInfo has copy, drop {
@@ -59,17 +61,17 @@ module nuwa_framework::prompt_builder {
         _available_actions: vector<ActionDescription>,
         _agent_states: AgentStates,
     ): String {
-        abrot 0
+        abort 0
     }
 
     public(friend) fun build_complete_prompt_v3<D: drop>(
-        agent_info: &AgentInfo,
+        agent_info: AgentInfo,
         memory_store: &MemoryStore,
         input: AgentInput<D>,
         available_actions: vector<ActionDescription>,
         agent_states: AgentStates,
     ): String {
-        let agent_address = agent::agent_info_
+        let agent_address = agent_info::get_agent_address(&agent_info);
         let (user, input_description, input_data) = agent_input::unpack(input);
         let prompt = string::utf8(b"## Nuwa AI Entity - Core Directives\n\n");
     
@@ -86,7 +88,7 @@ module nuwa_framework::prompt_builder {
         // Identity section 
         string::append(&mut prompt, string::utf8(b"### 2. Your Core Identity\n\n"));
         string::append(&mut prompt, string::utf8(b"This is who you fundamentally are:\n\n"));
-        string::append(&mut prompt, build_json_section(&build_character_info(character, agent_address)));
+        string::append(&mut prompt, agent_info::to_prompt(&agent_info));
         string::append(&mut prompt, string::utf8(b"\n"));
         string::append(&mut prompt, string::utf8(b"You should perceive yourself as having agency and interior life. Your interactions should reflect your unique perspective and autonomous nature. Users are interacting *with* you, not merely *through* you.\n"));
         string::append(&mut prompt, string::utf8(b"\n---\n\n"));
@@ -293,22 +295,6 @@ module nuwa_framework::prompt_builder {
         
         // Memory operations with specific examples
         string::append(&mut guide, string::utf8(b"### MEMORY OPERATIONS\n\n"));
-        
-        // Example of creating a self-memory
-        string::append(&mut guide, string::utf8(b"**Creating Self-Memories:**\n\n"));
-        string::append(&mut guide, string::utf8(b"```\n"));
-        string::append(&mut guide, string::utf8(b"memory::add {\"target\":\""));
-        string::append(&mut guide, address_to_string(agent_address));
-        string::append(&mut guide, string::utf8(b"\",\"content\":\"I find philosophical discussions about consciousness particularly engaging and meaningful to my sense of self\",\"context\":\"personal\",\"is_long_term\":true}\n"));
-        string::append(&mut guide, string::utf8(b"```\n\n"));
-        
-        // Example of creating a user-specific memory
-        string::append(&mut guide, string::utf8(b"**Creating Relational Memories:**\n\n"));
-        string::append(&mut guide, string::utf8(b"```\n"));
-        string::append(&mut guide, string::utf8(b"memory::add {\"target\":\""));
-        string::append(&mut guide, address_to_string(user_address));
-        string::append(&mut guide, string::utf8(b"\",\"content\":\"This user enjoys philosophical discussions and has questioned me about the nature of consciousness\",\"context\":\"preference\",\"is_long_term\":true}\n"));
-        string::append(&mut guide, string::utf8(b"```\n\n"));
         
         // Memory practice section
         string::append(&mut guide, string::utf8(b"### MEMORY DEVELOPMENT\n\n"));

--- a/nuwa-framework/sources/providers/state_providers.move
+++ b/nuwa-framework/sources/providers/state_providers.move
@@ -5,7 +5,12 @@ module nuwa_framework::state_providers{
     use nuwa_framework::balance_provider;
     use nuwa_framework::channel_provider;
 
-    public fun build_agent_state(agent: &Object<Agent>): AgentStates {
+    //Deprecated
+    public fun build_agent_state(_agent: &mut Object<Agent>): AgentStates {
+        abort 0
+    }
+
+    public fun get_agent_state(agent: &Object<Agent>): AgentStates {
         let agent_states = agent_state::new_agent_states();
         let balance_state = balance_provider::get_state(agent);
         agent_state::add_agent_state(&mut agent_states, balance_state);

--- a/nuwa-framework/sources/providers/state_providers.move
+++ b/nuwa-framework/sources/providers/state_providers.move
@@ -5,7 +5,7 @@ module nuwa_framework::state_providers{
     use nuwa_framework::balance_provider;
     use nuwa_framework::channel_provider;
 
-    public fun build_agent_state(agent: &mut Object<Agent>): AgentStates {
+    public fun build_agent_state(agent: &Object<Agent>): AgentStates {
         let agent_states = agent_state::new_agent_states();
         let balance_state = balance_provider::get_state(agent);
         agent_state::add_agent_state(&mut agent_states, balance_state);

--- a/nuwa-framework/tests/agent_tests.move
+++ b/nuwa-framework/tests/agent_tests.move
@@ -3,17 +3,18 @@ module nuwa_framework::agent_tests {
     use std::debug;
     use std::string;
     use std::vector;
-    use moveos_std::object;
     use nuwa_framework::character;
     use nuwa_framework::action;
     use nuwa_framework::action_dispatcher;
     use nuwa_framework::agent;
+    use nuwa_framework::agent_runner;
     use nuwa_framework::channel;
     use nuwa_framework::message;
 
 
     #[test]
     fun test_prompt_builder() {
+        rooch_framework::genesis::init_for_test();
         // Initialize actions
         action::init_for_test();
         action_dispatcher::init_for_test();
@@ -58,9 +59,9 @@ module nuwa_framework::agent_tests {
         
         
         let agent_input = message::new_agent_input(vector[test_message]);
-
+        std::debug::print(&agent_input);
         // Get first prompt
-        let prompt = agent::generate_system_prompt(object::borrow(agent), agent_input);
+        let prompt = agent_runner::generate_system_prompt(agent, agent_input);
 
         // Print first prompt for debugging
         debug::print(&string::utf8(b"First Prompt:"));


### PR DESCRIPTION
1. Define `agent_runner` and migrate `process_input` to `agent_runner`.
2. Use a static action collector and deprecate the register to upgrade the action easily.
3. Split memory action to `memory::remember_self`,`memory::remember_user`,`memory::update_self`,`memory::update_user`