### PR TITLE
feat(cadop-api): improve health check endpoint and add production start script

### DIFF
--- a/nuwa-services/cadop-service/typescript/packages/cadop-api/package.json
+++ b/nuwa-services/cadop-service/typescript/packages/cadop-api/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -b --force",
     "postbuild": "cp package.json dist/",
     "start": "node --experimental-specifier-resolution=node dist/index.js",
+    "start:prod": "NODE_ENV=production node --experimental-specifier-resolution=node dist/index.js",
     "predev": "pnpm --filter @cadop/shared build",
     "dev": "tsx watch src/index.ts",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/nuwa-services/cadop-service/typescript/packages/cadop-api/src/routes/health.ts
+++ b/nuwa-services/cadop-service/typescript/packages/cadop-api/src/routes/health.ts
@@ -8,11 +8,13 @@ router.get(
   '/',
   asyncHandler(async (_req: Request, res: Response) => {
     const healthCheck = {
+      service: 'cadop-api',
       status: 'OK',
       timestamp: new Date().toISOString(),
       uptime: process.uptime(),
       environment: process.env['NODE_ENV'] || 'development',
       version: process.env['npm_package_version'] || '1.0.0',
+      buildTime: new Date().toISOString(),
     };
 
     res.status(200).json(healthCheck);


### PR DESCRIPTION


- Add service name and build time to health check response
- Add start:prod script for production deployment
- Improve deployment monitoring capabilities