### PR TITLE
fix: address review comments from PR #496 for AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ This repo is a pnpm monorepo for the Nuwa Protocol ecosystem.
 - `nuwa-services/*`: backend services (e.g. `llm-gateway`, `mcp-server-proxy`, `cadop-service`).
 - `contracts/move/rooch/*`: Rooch Move smart contracts (e.g. `acp-registry/`).
 - `nips/`: protocol proposals/spec discussions.
-- `website/` and `docs/`: documentation and site content.
-- `deps/`: vendored dependencies / submodules (see `.gitmodules`).
+- `docs/`: documentation and site content.
+- `deps/`: vendored dependencies / submodules (see `.gitmodules`). This directory appears only after initializing submodules (e.g., with `git submodule update --init --recursive`).
 
 Each major directory has its own `README.md` with component-specific setup.
 
@@ -38,7 +38,7 @@ Move contracts (example):
 ## Coding Style & Naming Conventions
 
 - Formatting: Prettier (`.prettierrc`) with 2-space indentation, single quotes, semicolons, `printWidth: 100`.
-- Linting: ESLint for TypeScript (`.eslintrc.js`); unused args should be prefixed with `_` and avoid `console.log` (prefer `console.warn/error`).
+- Linting: ESLint for TypeScript (`.eslintrc.js`); unused args should be prefixed with `_`; `console.log` will trigger a lint warning (prefer `console.warn` or `console.error`, which are allowed).
 - Keep build artifacts out of PRs (`dist/`, `build/`, `coverage/`).
 
 ## Testing Guidelines


### PR DESCRIPTION
## Summary
This PR addresses the review comments from the merged PR #496 regarding the AGENTS.md file.

## Changes
- Remove reference to `website/` directory as it's mostly empty, keep only `docs/` for documentation
- Add clarification that `deps/` directory appears only after initializing submodules (e.g., with `git submodule update --init --recursive`)
- Correct the `console.log` linting description to accurately reflect that it triggers warnings but `console.warn` and `console.error` are allowed according to `.eslintrc.js`

## Test plan
- [ ] Verify the documentation accurately reflects the repository structure
- [ ] Ensure all changes are consistent with the actual codebase configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)