### PR TITLE
fix(mcp-server-proxy): replace createFastMcpServer with createMcpServer

### DIFF
--- a/nuwa-services/mcp-server-proxy/src/server.ts
+++ b/nuwa-services/mcp-server-proxy/src/server.ts
@@ -61,7 +61,7 @@ async function startServer(
     serverOptions.debug = config.debug;
   }
 
-  const app: any = await createFastMcpServer(serverOptions);
+  const app: any = await createMcpServer(serverOptions);
 
   // Prepare upstream via shared helper if configured
   let upstream: Upstream | undefined;


### PR DESCRIPTION
## Summary
- Fix regression in mcp-server-proxy after PR #493
- Replace undefined `createFastMcpServer` with the correctly imported `createMcpServer` function
- The code was importing `createMcpServer` from `@nuwa-ai/payment-kit` but still using the undefined `createFastMcpServer` function

## Test plan
- [x] Verified that `createMcpServer` is correctly imported from `@nuwa-ai/payment-kit`
- [x] Confirmed the function call matches the import statement
- [x] Checked that the TypeScript syntax is correct
- [x] The fix is minimal and targeted, addressing only the regression described in #498

## Additional Notes
This PR addresses the regression issue #498 where the mcp-server-proxy service would fail to start due to the use of an undefined `createFastMcpServer` function. The fix ensures that the code uses the correctly imported `createMcpServer` function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)