### PR TITLE
fix(payment-kit): migrate SdkMcpStarter to StreamableHTTPServerTransport with session routing

### DIFF
--- a/nuwa-kit/typescript/packages/payment-kit/src/transport/mcp/SdkMcpStarter.ts
+++ b/nuwa-kit/typescript/packages/payment-kit/src/transport/mcp/SdkMcpStarter.ts
@@ -451,7 +451,7 @@ export async function createSdkMcpServer(opts: SdkMcpServerOptions): Promise<{
         const origin = req.headers.origin;
         setCorsHeaders(origin);
         res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id');
+        res.setHeader('Access-Control-Allow-Headers', '*');
         res.writeHead(204);
         res.end();
         return;


### PR DESCRIPTION
## Summary
- Migrate SdkMcpStarter from SSEServerTransport to StreamableHTTPServerTransport
- Implement proper session routing keyed by \`mcp-session-id\` header
- Add support for POST (initialization), GET, and DELETE on the same \`/mcp\` endpoint
- Ensure tool invocation returns MCP-native CallToolResult format
- Maintain parity with existing endpoints and behavior

## Implementation Details

### Transport Migration
- **From**: \`SSEServerTransport\` (Server-Sent Events)
- **To**: \`StreamableHTTPServerTransport\` (HTTP request/response)

### Session Management
- Each POST request without \`mcp-session-id\` creates a new session
- Session ID is returned in response header for subsequent requests
- GET/DELETE requests require existing \`mcp-session-id\` header
- Proper session cleanup on server stop

### Request Routing
- \`POST /mcp\`: Initialize session, create transport+server, connect, then handle request
- \`GET /mcp\`: Route to existing session transport  
- \`DELETE /mcp\`: Route to existing session transport
- All existing endpoints preserved (\`/health\`, \`/ready\`, \`/.well-known/nuwa-payment/info\`)

### Tool Response Format
- Returns MCP-native \`{ content: [...] }\` format from \`kit.invoke()\` when available
- Falls back to stringified response for backward compatibility
- Proper error handling and logging

### CORS Support
- Proper preflight handling with OPTIONS requests
- CORS headers configured for browser compatibility
- Session ID exposure via \`Access-Control-Expose-Headers\`

## Test Plan
- [ ] Verify end-to-end Streamable HTTP flow works (init + subsequent requests)
- [ ] Test \`listTools\` and \`callTool\` against SDK engine with expected response shapes
- [ ] Ensure no regression to fastmcp default engine
- [ ] Test session cleanup on server stop
- [ ] Validate CORS behavior in browsers
- [ ] Test built-in endpoints remain functional

## Breaking Changes
None - this maintains backward compatibility with the existing SdkMcpStarter API.

Fixes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)