### PR TITLE
fix: Wire SDK engine billing integration for full MCP parity

### DIFF
--- a/nuwa-kit/typescript/packages/payment-kit/src/transport/mcp/SdkMcpStarter.ts
+++ b/nuwa-kit/typescript/packages/payment-kit/src/transport/mcp/SdkMcpStarter.ts
@@ -108,8 +108,8 @@ export class PaymentMcpToolRegistrar {
 
     this.registeredTools.push({
       ...toolDef,
-      handler: async (params: any) => {
-        return await this.kit.invoke(name, params, {});
+      handler: async (params: any, context?: any) => {
+        return await this.kit.invoke(name, params, context);
       },
     });
   }
@@ -288,13 +288,17 @@ export async function createSdkMcpServer(opts: SdkMcpServerOptions): Promise<{
     const toolDef = {
       name,
       description: `Built-in payment tool: ${name}`,
-      inputSchema: undefined, // Use permissive schema
+      inputSchema: {
+        type: 'object',
+        additionalProperties: true, // Allow reserved fields
+        properties: {},
+      }, // Use permissive schema that supports reserved fields
     };
 
     bootstrapRegistrar.registeredTools.push({
       ...toolDef,
-      handler: async (params: any) => {
-        return await kit.invoke(name, params, {});
+      handler: async (params: any, context?: any) => {
+        return await kit.invoke(name, params, context);
       },
     });
   }
@@ -347,7 +351,7 @@ export async function createSdkMcpServer(opts: SdkMcpServerOptions): Promise<{
       }
 
       try {
-        const result = await tool.handler(args);
+        const result = await tool.handler(args, request.context);
         // Return MCP-native format - prefer returning kit.invoke() directly when it returns { content: [...] }
         if (result && typeof result === 'object' && Array.isArray(result.content)) {
           return result;


### PR DESCRIPTION
## Summary
- Fixes critical context passing bugs in SDK engine that prevented billing/auth flows from working
- Ensures tool registration supports free + paid tools with proper input schema handling
- Enables Nuwa reserved args (`__nuwa_auth`, `__nuwa_payment`) to work correctly in SDK engine
- Achieves full parity between FastMCP and SDK engines for billing integration

## Test plan
- [x] All McpEngineParity tests pass (13/14 passing, 1 unrelated CommonJS failure)
- [x] Context flows correctly through billing middleware
- [x] Free tools work identically under both engines
- [x] Paid tools work identically under both engines  
- [x] Built-in tools support reserved parameters
- [x] No regressions in existing functionality

## Technical Details
Fixed 4 critical issues in `SdkMcpStarter.ts`:

1. **Line 111-113**: Fixed context passing in `PaymentMcpToolRegistrar.addTool()` method
2. **Line 296-298**: Fixed context passing for built-in tools registration
3. **Line 350**: Fixed context passing in `CallToolRequestSchema` handler
4. **Line 291-295**: Fixed built-in tools schema to support reserved fields

Context now properly flows through `McBillingMiddleware`, enabling authentication (`__nuwa_auth`) and payment processing (`__nuwa_payment`) to work correctly with the SDK engine.

Resolves: #491