### PR TITLE
feat(cadop-web): improve onboarding UX, metadata, and branding

### DIFF
--- a/nuwa-services/cadop-service/packages/cadop-web/index.html
+++ b/nuwa-services/cadop-service/packages/cadop-web/index.html
@@ -1,16 +1,16 @@
 <!doctype html>
-<html lang="zh">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Nuwa CADOP Service</title>
+    <title>Nuwa ID | Secure DID Access</title>
     <meta
       name="description"
-      content="Custodian-Assisted DID Onboarding Protocol Service - 创建和管理您的 DID，增强您的 Web3 身份"
+      content="Create and manage your Nuwa DID with passkey authentication, then securely authorize keys for agent and app workflows."
     />
-    <link rel="icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <meta name="theme-color" content="#ffffff" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
+    <meta name="theme-color" content="#0f172a" />
     <link rel="manifest" href="/manifest.json" />
   </head>
   <body>

--- a/nuwa-services/cadop-service/packages/cadop-web/public/favicon.svg
+++ b/nuwa-services/cadop-service/packages/cadop-web/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="nuwaIdLogoBg" x1="24" y1="20" x2="136" y2="140" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4F46E5"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+    <linearGradient id="nuwaIdLogoRing" x1="50" y1="50" x2="110" y2="110" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#A5F3FC"/>
+      <stop offset="1" stop-color="#E0E7FF"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="144" height="144" rx="36" fill="url(#nuwaIdLogoBg)"/>
+  <circle cx="80" cy="74" r="26" stroke="url(#nuwaIdLogoRing)" stroke-width="10"/>
+  <path d="M48 116C54 101 66 94 80 94C94 94 106 101 112 116" stroke="#E0F2FE" stroke-width="10" stroke-linecap="round"/>
+</svg>

--- a/nuwa-services/cadop-service/packages/cadop-web/public/manifest.json
+++ b/nuwa-services/cadop-service/packages/cadop-web/public/manifest.json
@@ -1,11 +1,11 @@
 {
-  "name": "CADOP Service",
-  "short_name": "CADOP",
-  "description": "Custodian-Assisted DID Onboarding Protocol Service - 创建和管理您的 DID，增强您的 Web3 身份",
+  "name": "Nuwa ID",
+  "short_name": "Nuwa ID",
+  "description": "Passkey-based DID onboarding and secure key authorization for agent and app workflows.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#ffffff",
+  "background_color": "#020617",
+  "theme_color": "#0f172a",
   "icons": [
     {
       "src": "/icon-192x192.png",

--- a/nuwa-services/cadop-service/packages/cadop-web/src/app.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/app.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { ProtectedRoute } from './components/auth/ProtectedRoute';
 import { LoginPage } from './pages/auth/login';
 import { DashboardPage } from './pages/dashboard';
@@ -15,9 +15,69 @@ import { Toaster } from './components/ui/toaster';
 import { DebugLogger } from '@nuwa-ai/identity-kit';
 
 const GLOBAL_DEBUG = import.meta.env.DEV;
+const DEFAULT_TITLE = 'Nuwa ID';
+const DEFAULT_DESCRIPTION =
+  'Create and manage your Nuwa DID with passkey authentication, then securely authorize keys for agent and app workflows.';
+
+function getPageMeta(pathname: string): { title: string; description: string } {
+  if (pathname.startsWith('/add-key')) {
+    return {
+      title: 'Authorize Key Request | Nuwa ID',
+      description: 'Review the key request and authorize it to your DID only when you trust the source.',
+    };
+  }
+  if (pathname.startsWith('/setup')) {
+    return {
+      title: 'Create Your DID | Nuwa ID',
+      description: 'Set up your passkey and create your DID in a guided flow.',
+    };
+  }
+  if (pathname.startsWith('/auth/login')) {
+    return {
+      title: 'Sign In | Nuwa ID',
+      description: 'Sign in with passkey or wallet to continue to your DID workspace.',
+    };
+  }
+  if (pathname.startsWith('/dashboard')) {
+    return {
+      title: 'Dashboard | Nuwa ID',
+      description: 'Manage your DID profile, keys, and service authorization status.',
+    };
+  }
+  if (pathname.startsWith('/create-agent-did')) {
+    return {
+      title: 'Create Agent DID | Nuwa ID',
+      description: 'Create a DID for agent workflows and keep ownership under your account.',
+    };
+  }
+  if (pathname.startsWith('/close')) {
+    return {
+      title: 'Completed | Nuwa ID',
+      description: 'This authorization flow is completed. You can close this window safely.',
+    };
+  }
+
+  return {
+    title: DEFAULT_TITLE,
+    description: DEFAULT_DESCRIPTION,
+  };
+}
 
 const App: React.FC = () => {
+  const location = useLocation();
+
   DebugLogger.setGlobalLevel(GLOBAL_DEBUG ? 'debug' : 'info');
+
+  React.useEffect(() => {
+    const { title, description } = getPageMeta(location.pathname);
+    document.title = title;
+
+    const descriptionMeta = document.querySelector('meta[name="description"]');
+    if (descriptionMeta) {
+      descriptionMeta.setAttribute('content', description);
+    }
+  }, [location.pathname]);
+
   return (
     <>
       <Routes>

--- a/nuwa-services/cadop-service/packages/cadop-web/src/components/layout/Header.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/components/layout/Header.tsx
@@ -43,7 +43,7 @@ export const Header = ({ onToggleSidebar }: HeaderProps) => {
               </svg>
             </button>
             <div className="ml-4 text-xl font-semibold text-gray-900 dark:text-white">
-              Nuwa CADOP
+              Nuwa ID
             </div>
           </div>
 

--- a/nuwa-services/cadop-service/packages/cadop-web/src/components/ui/FixedCardLayout.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/components/ui/FixedCardLayout.tsx
@@ -21,20 +21,25 @@ export function FixedCardLayout({
   icon,
 }: FixedCardLayoutProps) {
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-slate-950 p-4">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-24 -left-24 h-72 w-72 rounded-full bg-indigo-500/25 blur-3xl" />
+        <div className="absolute top-1/3 -right-16 h-80 w-80 rounded-full bg-cyan-400/20 blur-3xl" />
+        <div className="absolute -bottom-16 left-1/3 h-64 w-64 rounded-full bg-sky-500/20 blur-3xl" />
+      </div>
       <div
         className={cn(
-          'w-full max-w-lg bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden',
+          'relative w-full max-w-lg overflow-hidden rounded-3xl border border-white/20 bg-white/95 shadow-2xl shadow-slate-900/30 backdrop-blur',
           'aspect-[3/4] flex flex-col', // Fixed 3:4 aspect ratio
           className
         )}
       >
         {/* Header area */}
         {(title || subtitle || icon) && (
-          <div className="px-8 pt-8 pb-4 text-center">
+          <div className="px-8 pb-4 pt-8 text-center">
             {icon && <div className="mb-4 flex justify-center">{icon}</div>}
-            {title && <h2 className="text-2xl font-semibold text-gray-900 mb-2">{title}</h2>}
-            {subtitle && <p className="text-gray-600 text-sm">{subtitle}</p>}
+            {title && <h2 className="mb-2 text-2xl font-semibold text-gray-900">{title}</h2>}
+            {subtitle && <p className="text-sm text-gray-600">{subtitle}</p>}
           </div>
         )}
 
@@ -43,7 +48,7 @@ export function FixedCardLayout({
 
         {/* Bottom action button area */}
         {actions && (
-          <div className="px-8 py-6 border-t border-gray-100 bg-gray-50/50">
+          <div className="border-t border-gray-200/80 bg-gradient-to-b from-white to-slate-50 px-8 py-6">
             <div className="flex flex-col gap-3">{actions}</div>
           </div>
         )}

--- a/nuwa-services/cadop-service/packages/cadop-web/src/pages/auth/login.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/pages/auth/login.tsx
@@ -26,43 +26,53 @@ export function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-      <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <h1 className="text-center text-3xl font-extrabold text-gray-900">Welcome to CADOP</h1>
-        <p className="mt-2 text-center text-sm text-gray-600">
-          Choose your preferred sign-in method
-        </p>
+    <div className="relative min-h-screen overflow-hidden bg-slate-950">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-24 -left-24 h-72 w-72 rounded-full bg-indigo-500/30 blur-3xl" />
+        <div className="absolute top-1/3 right-0 h-80 w-80 rounded-full bg-cyan-400/20 blur-3xl" />
+        <div className="absolute bottom-0 left-1/4 h-64 w-64 rounded-full bg-sky-500/20 blur-3xl" />
       </div>
 
-      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-          {/* Error message */}
-          {error && (
-            <div className="mb-6 p-4 rounded-md bg-red-50">
-              <div className="flex">
-                <div className="flex-shrink-0">
-                  <svg
-                    className="h-5 w-5 text-red-400"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div className="ml-3">
-                  <p className="text-sm font-medium text-red-800">{error}</p>
+      <div className="relative flex min-h-screen flex-col justify-center py-12 sm:px-6 lg:px-8">
+        <div className="sm:mx-auto sm:w-full sm:max-w-md">
+          <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl border border-white/20 bg-white/10 p-2 shadow-xl backdrop-blur">
+            <img src="/favicon.svg" alt="Nuwa ID" className="h-full w-full object-contain" />
+          </div>
+          <p className="text-center text-xs uppercase tracking-[0.24em] text-cyan-200/80">Nuwa ID</p>
+          <h1 className="mt-3 text-center text-3xl font-bold text-white">Secure DID Sign-In</h1>
+          <p className="mt-2 text-center text-sm text-slate-200/80">
+            Continue with passkey or wallet to access your DID workspace.
+          </p>
+        </div>
+
+        <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+          <div className="rounded-2xl border border-white/15 bg-white/95 px-4 py-8 shadow-2xl shadow-slate-900/30 backdrop-blur sm:px-10">
+            {error && (
+              <div className="mb-6 rounded-md border border-red-200 bg-red-50 p-4">
+                <div className="flex">
+                  <div className="flex-shrink-0">
+                    <svg
+                      className="h-5 w-5 text-red-400"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div className="ml-3">
+                    <p className="text-sm font-medium text-red-800">{error}</p>
+                  </div>
                 </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {/* Authentication method selector */}
-          <AuthMethodSelector onSuccess={handleLoginSuccess} onError={handleLoginError} />
+            <AuthMethodSelector onSuccess={handleLoginSuccess} onError={handleLoginError} />
+          </div>
         </div>
       </div>
     </div>

--- a/nuwa-services/cadop-service/packages/cadop-web/src/styles/index.css
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/styles/index.css
@@ -9,7 +9,12 @@
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: rgb(var(--background-rgb));
+  background:
+    radial-gradient(1200px 520px at -10% -20%, rgba(59, 130, 246, 0.08), transparent 55%),
+    radial-gradient(900px 460px at 110% 15%, rgba(14, 165, 233, 0.08), transparent 50%),
+    rgb(var(--background-rgb));
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- improve cadop-web page metadata and branding copy for end users
- add route-aware page titles/descriptions in `src/app.tsx`
- refresh login page visuals with Nuwa ID branding and clearer sign-in messaging
- upgrade shared fixed-card layout styling used by add-key/onboarding flows
- add `public/favicon.svg` (Nuwa DID logo) and wire it in `index.html`
- update PWA manifest name/description/theme colors to match Nuwa ID

## Validation
- `pnpm --filter @cadop/web build`
