### PR TITLE
fix(cadop-web): enforce light-only theme across auth/onboarding

### DIFF
--- a/nuwa-services/cadop-service/packages/cadop-web/index.html
+++ b/nuwa-services/cadop-service/packages/cadop-web/index.html
@@ -10,7 +10,7 @@
     />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/favicon.svg" />
-    <meta name="theme-color" content="#0f172a" />
+    <meta name="theme-color" content="#f8fafc" />
     <link rel="manifest" href="/manifest.json" />
   </head>
   <body>

--- a/nuwa-services/cadop-service/packages/cadop-web/public/manifest.json
+++ b/nuwa-services/cadop-service/packages/cadop-web/public/manifest.json
@@ -4,8 +4,8 @@
   "description": "Passkey-based DID onboarding and secure key authorization for agent and app workflows.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#020617",
-  "theme_color": "#0f172a",
+  "background_color": "#f8fafc",
+  "theme_color": "#f8fafc",
   "icons": [
     {
       "src": "/icon-192x192.png",

--- a/nuwa-services/cadop-service/packages/cadop-web/src/components/did/VerificationMethodForm.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/components/did/VerificationMethodForm.tsx
@@ -163,14 +163,14 @@ export function VerificationMethodForm({
       <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
         {/* Key Generation Section */}
         {did && (
-          <div className="border rounded-lg p-4 bg-blue-50 dark:bg-blue-950/20">
+          <div className="border rounded-lg p-4 bg-blue-50">
             <div className="flex items-center gap-2 mb-3">
               <Key className="h-4 w-4 text-blue-600" />
-              <h4 className="font-medium text-blue-900 dark:text-blue-100">
+              <h4 className="font-medium text-blue-900">
                 Generate New Key Pair
               </h4>
             </div>
-            <p className="text-sm text-blue-700 dark:text-blue-300 mb-3">
+            <p className="text-sm text-blue-700 mb-3">
               Generate a new cryptographic key pair for this DID. The private key will be provided
               as a Service Key for server deployment.
             </p>
@@ -227,13 +227,13 @@ export function VerificationMethodForm({
             )}
 
             {generatedKey && (
-              <Alert className="border-green-200 bg-green-50 dark:bg-green-950/20">
+              <Alert className="border-green-200 bg-green-50">
                 <Shield className="h-4 w-4 text-green-600" />
-                <AlertTitle className="text-green-800 dark:text-green-200">
+                <AlertTitle className="text-green-800">
                   Service Key Generated
                 </AlertTitle>
                 <AlertDescription className="mt-2">
-                  <p className="text-sm text-green-700 dark:text-green-300 mb-3">
+                  <p className="text-sm text-green-700 mb-3">
                     <strong>Important:</strong> Copy and save the Service Key immediately. You
                     won&apos;t be able to view it again.
                   </p>
@@ -258,9 +258,9 @@ export function VerificationMethodForm({
                     </Alert>
                   )}
 
-                  <div className="bg-white dark:bg-gray-800 border rounded p-3 mb-3">
+                  <div className="bg-white border rounded p-3 mb-3">
                     <div className="flex items-center justify-between">
-                      <code className="text-xs font-mono break-all pr-2 text-gray-700 dark:text-gray-300">
+                      <code className="text-xs font-mono break-all pr-2 text-gray-700">
                         {generatedKey.storedKeyString}
                       </code>
                       <CopyButton
@@ -270,7 +270,7 @@ export function VerificationMethodForm({
                       />
                     </div>
                   </div>
-                  <p className="text-xs text-green-600 dark:text-green-400">
+                  <p className="text-xs text-green-600">
                     Add this to your server environment variables:{' '}
                     <code>SERVICE_KEY=&quot;&lt;copied_value&gt;&quot;</code>
                   </p>
@@ -318,7 +318,7 @@ export function VerificationMethodForm({
                   placeholder="z...."
                   {...field}
                   readOnly={!!generatedKey}
-                  className={generatedKey ? 'bg-gray-50 dark:bg-gray-900' : ''}
+                  className={generatedKey ? 'bg-gray-50' : ''}
                 />
               </FormControl>
               {generatedKey && (

--- a/nuwa-services/cadop-service/packages/cadop-web/src/components/layout/Header.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/components/layout/Header.tsx
@@ -23,13 +23,13 @@ export const Header = ({ onToggleSidebar }: HeaderProps) => {
   };
 
   return (
-    <header className="fixed top-0 z-30 w-full bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+    <header className="fixed top-0 z-30 w-full bg-white border-b border-gray-200">
       <div className="px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center">
             <button
               type="button"
-              className="text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300 lg:hidden"
+              className="text-gray-500 hover:text-gray-600 lg:hidden"
               onClick={onToggleSidebar}
             >
               <span className="sr-only">Open sidebar</span>
@@ -42,7 +42,7 @@ export const Header = ({ onToggleSidebar }: HeaderProps) => {
                 />
               </svg>
             </button>
-            <div className="ml-4 text-xl font-semibold text-gray-900 dark:text-white">
+            <div className="ml-4 text-xl font-semibold text-gray-900">
               Nuwa ID
             </div>
           </div>
@@ -50,7 +50,7 @@ export const Header = ({ onToggleSidebar }: HeaderProps) => {
           <div className="flex items-center space-x-4">
             {/* Language Select */}
             <Select value={i18n.language} onValueChange={handleLanguageChange}>
-              <SelectTrigger className="h-8 w-20 border-none bg-transparent px-2 text-gray-500 dark:text-gray-400 focus:ring-0">
+              <SelectTrigger className="h-8 w-20 border-none bg-transparent px-2 text-gray-500 focus:ring-0">
                 <SelectValue placeholder={i18n.language === 'en' ? 'EN' : '中文'} />
               </SelectTrigger>
               <SelectContent>
@@ -66,7 +66,7 @@ export const Header = ({ onToggleSidebar }: HeaderProps) => {
               variant="ghost"
               size="sm"
               onClick={signOut}
-              className="text-gray-500 dark:text-gray-400"
+              className="text-gray-500"
             >
               {t('dashboard.signOut')}
             </Button>

--- a/nuwa-services/cadop-service/packages/cadop-web/src/components/ui/FixedCardLayout.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/components/ui/FixedCardLayout.tsx
@@ -21,15 +21,15 @@ export function FixedCardLayout({
   icon,
 }: FixedCardLayoutProps) {
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-slate-950 p-4">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-slate-50 p-4">
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute -top-24 -left-24 h-72 w-72 rounded-full bg-indigo-500/25 blur-3xl" />
-        <div className="absolute top-1/3 -right-16 h-80 w-80 rounded-full bg-cyan-400/20 blur-3xl" />
-        <div className="absolute -bottom-16 left-1/3 h-64 w-64 rounded-full bg-sky-500/20 blur-3xl" />
+        <div className="absolute -top-24 -left-24 h-72 w-72 rounded-full bg-indigo-200/60 blur-3xl" />
+        <div className="absolute top-1/3 -right-16 h-80 w-80 rounded-full bg-cyan-200/55 blur-3xl" />
+        <div className="absolute -bottom-16 left-1/3 h-64 w-64 rounded-full bg-sky-200/55 blur-3xl" />
       </div>
       <div
         className={cn(
-          'relative w-full max-w-lg overflow-hidden rounded-3xl border border-white/20 bg-white/95 shadow-2xl shadow-slate-900/30 backdrop-blur',
+          'relative w-full max-w-lg overflow-hidden rounded-3xl border border-slate-200/90 bg-white/95 shadow-2xl shadow-slate-300/40 backdrop-blur',
           'aspect-[3/4] flex flex-col', // Fixed 3:4 aspect ratio
           className
         )}

--- a/nuwa-services/cadop-service/packages/cadop-web/src/components/ui/alert.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/components/ui/alert.tsx
@@ -9,8 +9,7 @@ const alertVariants = cva(
     variants: {
       variant: {
         default: 'bg-background text-foreground',
-        destructive:
-          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+        destructive: 'border-destructive/50 text-destructive [&>svg]:text-destructive',
       },
     },
     defaultVariants: {

--- a/nuwa-services/cadop-service/packages/cadop-web/src/components/ui/typography.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/components/ui/typography.tsx
@@ -82,8 +82,8 @@ export const Text: React.FC<TextProps> = ({
   const typeClasses = {
     default: 'text-foreground',
     secondary: 'text-muted-foreground',
-    success: 'text-green-600 dark:text-green-500',
-    warning: 'text-amber-600 dark:text-amber-500',
+    success: 'text-green-600',
+    warning: 'text-amber-600',
     danger: 'text-destructive',
   };
 

--- a/nuwa-services/cadop-service/packages/cadop-web/src/main.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/main.tsx
@@ -11,6 +11,11 @@ import App from './app';
 import i18n from './i18n';
 import './styles/index.css';
 
+// Cadop web is intentionally light-only for now.
+document.documentElement.classList.remove('dark');
+document.body.classList.remove('dark');
+document.documentElement.style.colorScheme = 'light';
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/nuwa-services/cadop-service/packages/cadop-web/src/pages/auth/login.tsx
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/pages/auth/login.tsx
@@ -26,27 +26,27 @@ export function LoginPage() {
   };
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950">
+    <div className="relative min-h-screen overflow-hidden bg-slate-50">
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute -top-24 -left-24 h-72 w-72 rounded-full bg-indigo-500/30 blur-3xl" />
-        <div className="absolute top-1/3 right-0 h-80 w-80 rounded-full bg-cyan-400/20 blur-3xl" />
-        <div className="absolute bottom-0 left-1/4 h-64 w-64 rounded-full bg-sky-500/20 blur-3xl" />
+        <div className="absolute -top-24 -left-24 h-72 w-72 rounded-full bg-indigo-200/60 blur-3xl" />
+        <div className="absolute top-1/3 right-0 h-80 w-80 rounded-full bg-cyan-200/55 blur-3xl" />
+        <div className="absolute bottom-0 left-1/4 h-64 w-64 rounded-full bg-sky-200/55 blur-3xl" />
       </div>
 
       <div className="relative flex min-h-screen flex-col justify-center py-12 sm:px-6 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
-          <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl border border-white/20 bg-white/10 p-2 shadow-xl backdrop-blur">
+          <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl border border-slate-200 bg-white p-2 shadow-xl">
             <img src="/favicon.svg" alt="Nuwa ID" className="h-full w-full object-contain" />
           </div>
-          <p className="text-center text-xs uppercase tracking-[0.24em] text-cyan-200/80">Nuwa ID</p>
-          <h1 className="mt-3 text-center text-3xl font-bold text-white">Secure DID Sign-In</h1>
-          <p className="mt-2 text-center text-sm text-slate-200/80">
+          <p className="text-center text-xs uppercase tracking-[0.24em] text-sky-700/80">Nuwa ID</p>
+          <h1 className="mt-3 text-center text-3xl font-bold text-slate-900">Secure DID Sign-In</h1>
+          <p className="mt-2 text-center text-sm text-slate-600">
             Continue with passkey or wallet to access your DID workspace.
           </p>
         </div>
 
         <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-          <div className="rounded-2xl border border-white/15 bg-white/95 px-4 py-8 shadow-2xl shadow-slate-900/30 backdrop-blur sm:px-10">
+          <div className="rounded-2xl border border-slate-200/90 bg-white/95 px-4 py-8 shadow-2xl shadow-slate-300/40 backdrop-blur sm:px-10">
             {error && (
               <div className="mb-6 rounded-md border border-red-200 bg-red-50 p-4">
                 <div className="flex">

--- a/nuwa-services/cadop-service/packages/cadop-web/src/styles/index.css
+++ b/nuwa-services/cadop-service/packages/cadop-web/src/styles/index.css
@@ -61,45 +61,49 @@ body {
     --chart-5: 27 87% 67%;
   }
 
+  /*
+   * Cadop Web is currently light-only.
+   * Keep .dark mapped to the same palette to avoid mixed UI (e.g. dark dialogs over light pages).
+   */
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
+    --background: 0 0% 100%;
+    --foreground: 0 0% 3.9%;
 
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
+    --muted: 0 0% 96.1%;
+    --muted-foreground: 0 0% 45.1%;
 
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 3.9%;
 
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 3.9%;
 
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
+    --border: 0 0% 89.8%;
+    --input: 0 0% 89.8%;
 
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
 
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
+    --secondary: 0 0% 96.1%;
+    --secondary-foreground: 0 0% 9%;
 
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
+    --accent: 0 0% 96.1%;
+    --accent-foreground: 0 0% 9%;
 
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
 
-    --ring: 0 0% 83.1%;
+    --ring: 0 0% 3.9%;
 
-    --chart-1: 220 70% 50%;
+    --chart-1: 12 76% 61%;
 
-    --chart-2: 160 60% 45%;
+    --chart-2: 173 58% 39%;
 
-    --chart-3: 30 80% 55%;
+    --chart-3: 197 37% 24%;
 
-    --chart-4: 280 65% 60%;
+    --chart-4: 43 74% 66%;
 
-    --chart-5: 340 75% 55%;
+    --chart-5: 27 87% 67%;
   }
 }
 


### PR DESCRIPTION
## Summary
- enforce light-only mode at app boot (remove accidental `dark` class and set `color-scheme: light`)
- remove remaining `dark:*` style branches that could still render dark blocks in dialogs/forms
- align login/create-agent visual system to light background gradients
- sync web metadata colors (`theme-color`, manifest background/theme) to light values

## Why
Dashboard and onboarding/auth pages used mixed styling strategies. When any `dark` class leaked in, modal/token-based surfaces could become dark while page containers stayed light.

## Testing
- `pnpm --filter @cadop/web build`